### PR TITLE
[PRM-1133] Added new health reason for PEGA

### DIFF
--- a/app/models/appeals/AppealSubmission.scala
+++ b/app/models/appeals/AppealSubmission.scala
@@ -291,11 +291,12 @@ object HealthAppealInformation {
   implicit val healthAppealInformationFormatter: OFormat[HealthAppealInformation] = Json.format[HealthAppealInformation]
 
   val healthAppealWrites: Writes[HealthAppealInformation] = (healthAppealInformation: HealthAppealInformation) => {
+    val healthAppealReasonForPEGA = if(healthAppealInformation.hospitalStayInvolved) "unexpectedHospitalStay" else "seriousOrLifeThreateningIllHealth"
     Json.obj(
       "hospitalStayInvolved" -> healthAppealInformation.hospitalStayInvolved,
       "eventOngoing" -> healthAppealInformation.eventOngoing,
       "lateAppeal" -> healthAppealInformation.lateAppeal,
-      "reasonableExcuse" -> healthAppealInformation.reasonableExcuse,
+      "reasonableExcuse" -> healthAppealReasonForPEGA,
       "honestyDeclaration" -> healthAppealInformation.honestyDeclaration
     ).deepMerge(
       healthAppealInformation.statement.fold(
@@ -446,6 +447,10 @@ object AppealSubmission {
         Json.fromJson(payload)(TechnicalIssuesAppealInformation.technicalIssuesAppealInformationFormatter)
       case "health" =>
         Json.fromJson(payload)(HealthAppealInformation.healthAppealInformationFormatter)
+      case "unexpectedHospitalStay" =>
+        Json.fromJson(payload)(HealthAppealInformation.healthAppealInformationFormatter)
+      case "seriousOrLifeThreateningIllHealth" =>
+        Json.fromJson(payload)(HealthAppealInformation.healthAppealInformationFormatter)
       case "other" =>
         Json.fromJson(payload)(OtherAppealInformation.otherAppealInformationFormatter)
       case "obligation" =>
@@ -466,6 +471,10 @@ object AppealSubmission {
       case "technicalIssues" =>
         Json.toJson(payload.asInstanceOf[TechnicalIssuesAppealInformation])(TechnicalIssuesAppealInformation.technicalIssuesAppealWrites)
       case "health" =>
+        Json.toJson(payload.asInstanceOf[HealthAppealInformation])(HealthAppealInformation.healthAppealWrites)
+      case "unexpectedHospitalStay" =>
+        Json.toJson(payload.asInstanceOf[HealthAppealInformation])(HealthAppealInformation.healthAppealWrites)
+      case "seriousOrLifeThreateningIllHealth" =>
         Json.toJson(payload.asInstanceOf[HealthAppealInformation])(HealthAppealInformation.healthAppealWrites)
       case "other" =>
         Json.toJson(payload.asInstanceOf[OtherAppealInformation])(OtherAppealInformation.otherAppealInformationWrites)

--- a/app/models/appeals/AppealSubmission.scala
+++ b/app/models/appeals/AppealSubmission.scala
@@ -447,10 +447,6 @@ object AppealSubmission {
         Json.fromJson(payload)(TechnicalIssuesAppealInformation.technicalIssuesAppealInformationFormatter)
       case "health" =>
         Json.fromJson(payload)(HealthAppealInformation.healthAppealInformationFormatter)
-      case "unexpectedHospitalStay" =>
-        Json.fromJson(payload)(HealthAppealInformation.healthAppealInformationFormatter)
-      case "seriousOrLifeThreateningIllHealth" =>
-        Json.fromJson(payload)(HealthAppealInformation.healthAppealInformationFormatter)
       case "other" =>
         Json.fromJson(payload)(OtherAppealInformation.otherAppealInformationFormatter)
       case "obligation" =>
@@ -471,10 +467,6 @@ object AppealSubmission {
       case "technicalIssues" =>
         Json.toJson(payload.asInstanceOf[TechnicalIssuesAppealInformation])(TechnicalIssuesAppealInformation.technicalIssuesAppealWrites)
       case "health" =>
-        Json.toJson(payload.asInstanceOf[HealthAppealInformation])(HealthAppealInformation.healthAppealWrites)
-      case "unexpectedHospitalStay" =>
-        Json.toJson(payload.asInstanceOf[HealthAppealInformation])(HealthAppealInformation.healthAppealWrites)
-      case "seriousOrLifeThreateningIllHealth" =>
         Json.toJson(payload.asInstanceOf[HealthAppealInformation])(HealthAppealInformation.healthAppealWrites)
       case "other" =>
         Json.toJson(payload.asInstanceOf[OtherAppealInformation])(OtherAppealInformation.otherAppealInformationWrites)

--- a/test/models/appeals/AppealSubmissionSpec.scala
+++ b/test/models/appeals/AppealSubmissionSpec.scala
@@ -453,7 +453,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
   val healthAppealInformationHospitalStayNotOngoingJson: JsValue = Json.parse(
     """
       |{
-      |   "reasonableExcuse": "health",
+      |   "reasonableExcuse": "unexpectedHospitalStay",
       |   "honestyDeclaration": true,
       |   "startDateOfEvent": "2021-04-23T18:25:43.511Z",
       |   "endDateOfEvent": "2021-04-24T18:25:43.511Z",
@@ -469,7 +469,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
   val healthAppealInformationHospitalStayOngoingJson: JsValue = Json.parse(
     """
       |{
-      |   "reasonableExcuse": "health",
+      |   "reasonableExcuse": "unexpectedHospitalStay",
       |   "honestyDeclaration": true,
       |   "startDateOfEvent": "2021-04-23T18:25:43.511Z",
       |   "eventOngoing": true,
@@ -484,7 +484,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
   val healthAppealInformationNoHospitalStayJson: JsValue = Json.parse(
     """
       |{
-      |   "reasonableExcuse": "health",
+      |   "reasonableExcuse": "seriousOrLifeThreateningIllHealth",
       |   "honestyDeclaration": true,
       |   "startDateOfEvent": "2021-04-23T18:25:43.511Z",
       |   "hospitalStayInvolved": false,
@@ -738,7 +738,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
             isClientResponsibleForSubmission = Some(false),
             isClientResponsibleForLateSubmission = Some(true),
             honestyDeclaration = true,
-            reasonableExcuse = "health"
+            reasonableExcuse = "seriousOrLifeThreateningIllHealth"
           )
         }
 
@@ -756,7 +756,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
             isClientResponsibleForSubmission = Some(false),
             isClientResponsibleForLateSubmission = Some(true),
             honestyDeclaration = true,
-            reasonableExcuse = "health"
+            reasonableExcuse = "unexpectedHospitalStay"
           )
         }
 
@@ -774,7 +774,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
             isClientResponsibleForSubmission = Some(false),
             isClientResponsibleForLateSubmission = Some(true),
             honestyDeclaration = true,
-            reasonableExcuse = "health"
+            reasonableExcuse = "unexpectedHospitalStay"
           )
         }
       }
@@ -1660,7 +1660,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
             "isLPP" -> false,
             "agentReferenceNo" -> "AGENT1",
             "appealInformation" -> Json.obj(
-              "reasonableExcuse" -> "health",
+              "reasonableExcuse" -> "unexpectedHospitalStay",
               "honestyDeclaration" -> true,
               "startDateOfEvent" -> "2021-04-23T18:25:43.511Z",
               "endDateOfEvent" -> "2021-04-24T18:25:43.511Z",
@@ -1707,7 +1707,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
             "isLPP" -> false,
             "agentReferenceNo" -> "AGENT1",
             "appealInformation" -> Json.obj(
-              "reasonableExcuse" -> "health",
+              "reasonableExcuse" -> "unexpectedHospitalStay",
               "honestyDeclaration" -> true,
               "startDateOfEvent" -> "2021-04-23T18:25:43.511Z",
               "eventOngoing" -> true,
@@ -1754,7 +1754,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
             "isLPP" -> false,
             "agentReferenceNo" -> "AGENT1",
             "appealInformation" -> Json.obj(
-              "reasonableExcuse" -> "health",
+              "reasonableExcuse" -> "seriousOrLifeThreateningIllHealth",
               "honestyDeclaration" -> true,
               "startDateOfEvent" -> "2021-04-23T18:25:43.511Z",
               "eventOngoing" -> false,
@@ -2203,7 +2203,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
           )
           val result = Json.toJson(model)(HealthAppealInformation.healthAppealWrites)
           result shouldBe Json.obj(
-            "reasonableExcuse" -> "health",
+            "reasonableExcuse" -> "unexpectedHospitalStay",
             "startDateOfEvent" -> "2021-04-23T18:25:43.511Z",
             "endDateOfEvent" -> "2021-04-24T18:25:43.511Z",
             "eventOngoing" -> false,
@@ -2232,7 +2232,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
           )
           val result = Json.toJson(model)(HealthAppealInformation.healthAppealWrites)
           result shouldBe Json.obj(
-            "reasonableExcuse" -> "health",
+            "reasonableExcuse" -> "unexpectedHospitalStay",
             "startDateOfEvent" -> "2021-04-23T18:25:43.511Z",
             "eventOngoing" -> true,
             "hospitalStayInvolved" -> true,
@@ -2261,7 +2261,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
           )
           val result = Json.toJson(model)(HealthAppealInformation.healthAppealWrites)
           result shouldBe Json.obj(
-            "reasonableExcuse" -> "health",
+            "reasonableExcuse" -> "seriousOrLifeThreateningIllHealth",
             "startDateOfEvent" -> "2021-04-23T18:25:43.511Z",
             "eventOngoing" -> false,
             "hospitalStayInvolved" -> false,


### PR DESCRIPTION
submitAppeal to PEGA with new health reason 'unexpectedHospitalStay':

{
   "dateOfAppeal":"2022-03-04T12:32:33.083",
   "appealSubmittedBy":"client",
   "taxRegime":"VAT",
   "sourceSystem":"MDTP",
   "customerReferenceNo":"VRN224060020",
   "appealInformation":{
      "honestyDeclaration":true,
      "lateAppeal":true,
      "endDateOfEvent":"2021-05-02",
      "hospitalStayInvolved":true,
      "eventOngoing":false,
      "reasonableExcuse":"unexpectedHospitalStay",
      "lateAppealReason":"test reason",
      "startDateOfEvent":"2021-03-02"
   },
   "isLPP":false

submitAppeal to PEGA with new health reason 'seriousOrLifeThreateningIllHealth':

{
   "dateOfAppeal":"2022-03-04T12:29:54.935",
   "appealSubmittedBy":"client",
   "taxRegime":"VAT",
   "sourceSystem":"MDTP",
   "customerReferenceNo":"VRN224060020",
   "appealInformation":{
      "honestyDeclaration":true,
      "lateAppeal":true,
      "hospitalStayInvolved":false,
      "eventOngoing":false,
      "reasonableExcuse":"seriousOrLifeThreateningIllHealth",
      "lateAppealReason":"test",
      "startDateOfEvent":"2022-02-01"
   },
   "isLPP":false
}