### PR TITLE
[PRM-1419] - Added handling for 404 with body returned from GetPenaltyDetails call

### DIFF
--- a/app/models/v3/getPenaltyDetails/FailureCodeEnum.scala
+++ b/app/models/v3/getPenaltyDetails/FailureCodeEnum.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.v3.getPenaltyDetails
+
+import play.api.libs.json.{Format, JsError, JsResult, JsString, JsSuccess, JsValue}
+
+object FailureCodeEnum extends Enumeration {
+  val NoDataFound: FailureCodeEnum.Value = Value("NO_DATA_FOUND")
+
+  implicit val format: Format[FailureCodeEnum.Value] = new Format[FailureCodeEnum.Value] {
+    override def writes(o: FailureCodeEnum.Value): JsValue = {
+      JsString(o.toString)
+    }
+
+    override def reads(json: JsValue): JsResult[FailureCodeEnum.Value] = {
+      json.as[String].toUpperCase match {
+        case "NO_DATA_FOUND" => JsSuccess(NoDataFound)
+        case e => JsError(s"$e not recognised")
+      }
+    }
+  }
+}

--- a/app/models/v3/getPenaltyDetails/FailureResponse.scala
+++ b/app/models/v3/getPenaltyDetails/FailureResponse.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.v3.getPenaltyDetails
+
+import play.api.libs.json.{Format, Json}
+
+case class FailureResponse(code: FailureCodeEnum.Value, reason: String)
+
+object FailureResponse {
+  implicit val format: Format[FailureResponse] = Json.format[FailureResponse]
+}

--- a/it/controllers/PenaltiesFrontendControllerISpec.scala
+++ b/it/controllers/PenaltiesFrontendControllerISpec.scala
@@ -419,7 +419,7 @@ class PenaltiesFrontendControllerISpec extends IntegrationSpecCommonBase with ET
       }
     }
 
-    s"return BAD_REQUEST (${Status.NOT_FOUND})" when {
+    s"return NOT_FOUND (${Status.NOT_FOUND})" when {
       "the user supplies an invalid VRN" in {
         mockStubResponseForGetPenaltyDetailsv3(Status.OK, "123456789", body = Some(getPenaltyDetailsJson.toString()))
         val result = await(buildClientForRequestToApp(uri = "/etmp/penalties/123456789123456789?newApiModel=true").get)

--- a/test/models/v3/getPenaltyDetails/FailureCodeEnumSpec.scala
+++ b/test/models/v3/getPenaltyDetails/FailureCodeEnumSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.v3.getPenaltyDetails
+
+import base.SpecBase
+import play.api.libs.json.{JsString, Json}
+
+class FailureCodeEnumSpec extends SpecBase {
+  "be writable to JSON for 'NO_DATA_FOUND'" in {
+    val result = Json.toJson(FailureCodeEnum.NoDataFound)
+    result shouldBe JsString("NO_DATA_FOUND")
+  }
+
+  "be readable from JSON for 'NO_DATA_FOUND'" in {
+    val result = Json.fromJson(JsString("NO_DATA_FOUND"))(FailureCodeEnum.format)
+    result.get shouldBe FailureCodeEnum.NoDataFound
+  }
+}

--- a/test/models/v3/getPenaltyDetails/FailureResponseSpec.scala
+++ b/test/models/v3/getPenaltyDetails/FailureResponseSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.v3.getPenaltyDetails
+
+import base.SpecBase
+import play.api.libs.json.{JsValue, Json}
+
+class FailureResponseSpec extends SpecBase {
+  val jsonRepresentingModel: JsValue = Json.parse(
+    """
+      |{
+      | "code": "NO_DATA_FOUND",
+      | "reason": "This is some reason"
+      |}
+      |""".stripMargin)
+
+  val model: FailureResponse = FailureResponse(
+    code = FailureCodeEnum.NoDataFound, reason = "This is some reason"
+  )
+
+  "be readable from JSON" in {
+    val result = Json.fromJson[FailureResponse](jsonRepresentingModel)(FailureResponse.format)
+    result.isSuccess shouldBe true
+    result.get shouldBe model
+  }
+
+  "be writable to JSON" in {
+    val result = Json.toJson(model)(FailureResponse.format)
+    result shouldBe jsonRepresentingModel
+  }
+}


### PR DESCRIPTION
Currently throws a warning about a not exhaustive check in GetPenaltyDetailsService (which will be covered in PRM-1420)
Has some redundant checking in the parser:
![image](https://user-images.githubusercontent.com/53828896/172574364-effba589-19bc-4d70-a462-9d508228b74a.png)
This is to make the code more robust in case we need to add any more cases