### PR TITLE
[DL-16563] Add appealLevel to submission body only when calling HIP API

### DIFF
--- a/app/connectors/PEGAConnector.scala
+++ b/app/connectors/PEGAConnector.scala
@@ -17,11 +17,13 @@
 package connectors
 
 import config.AppConfig
+import config.featureSwitches.CallAPI1808HIP
 import connectors.parsers.AppealsParser.{AppealSubmissionResponse, AppealSubmissionResponseReads, UnexpectedFailure}
 import models.appeals.AppealSubmission
 import play.api.http.HeaderNames._
 import play.api.http.MimeTypes
 import play.api.http.Status.INTERNAL_SERVER_ERROR
+import play.api.libs.json.Writes
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, UpstreamErrorResponse}
 import utils.Logger.logger
 import utils.PagerDutyHelper
@@ -30,34 +32,44 @@ import utils.PagerDutyHelper.PagerDutyKeys._
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class PEGAConnector @Inject()(httpClient: HttpClient,
-                              appConfig: AppConfig)(implicit ec: ExecutionContext) {
+class PEGAConnector @Inject() (httpClient: HttpClient, appConfig: AppConfig)(implicit ec: ExecutionContext) {
 
-  def submitAppeal(appealSubmission: AppealSubmission, enrolmentKey: String, isLPP: Boolean, penaltyNumber: String, correlationId: String): Future[AppealSubmissionResponse] = {
+  def submitAppeal(appealSubmission: AppealSubmission,
+                   enrolmentKey: String,
+                   isLPP: Boolean,
+                   penaltyNumber: String,
+                   correlationId: String): Future[AppealSubmissionResponse] = {
+
     implicit val hc: HeaderCarrier = headersForEIS(correlationId, appConfig.eiOutboundBearerToken, appConfig.eisEnvironment)
-    httpClient.POST[AppealSubmission, AppealSubmissionResponse](appConfig.getAppealSubmissionURL(enrolmentKey, isLPP, penaltyNumber), appealSubmission, hc.otherHeaders).recover {
-      case e: UpstreamErrorResponse => {
-        PagerDutyHelper.logStatusCode("submitAppeal", e.statusCode)(RECEIVED_4XX_FROM_1808_API, RECEIVED_5XX_FROM_1808_API)
-        logger.error(s"[PEGAConnector][submitAppeal] -" +
-          s" Received ${e.statusCode} status from API 1812 call - returning status to caller")
-        Left(UnexpectedFailure(e.statusCode, e.message))
+    implicit val writesAppealSubmission: Writes[AppealSubmission] =
+      if (appConfig.isEnabled(CallAPI1808HIP)) AppealSubmission.apiWritesHIP else AppealSubmission.apiWrites
+    val submitAppealUrl = appConfig.getAppealSubmissionURL(enrolmentKey, isLPP, penaltyNumber)
+
+    httpClient
+      .POST[AppealSubmission, AppealSubmissionResponse](submitAppealUrl, appealSubmission, hc.otherHeaders)
+      .recover {
+        case e: UpstreamErrorResponse =>
+          PagerDutyHelper.logStatusCode("submitAppeal", e.statusCode)(RECEIVED_4XX_FROM_1808_API, RECEIVED_5XX_FROM_1808_API)
+          logger.error(
+            s"[PEGAConnector][submitAppeal] -" +
+              s" Received ${e.statusCode} status from API 1812 call - returning status to caller")
+          Left(UnexpectedFailure(e.statusCode, e.message))
+        case e: Exception =>
+          PagerDutyHelper.log("submitAppeal", UNKNOWN_EXCEPTION_CALLING_1808_API)
+          logger.error(
+            s"[PEGAConnector][submitAppeal] -" +
+              s" An unknown exception occurred - returning 500 back to caller - message: ${e.getMessage}")
+          Left(UnexpectedFailure(INTERNAL_SERVER_ERROR, "An unknown exception occurred. Contact the Penalties team for more information."))
       }
-      case e: Exception => {
-        PagerDutyHelper.log("submitAppeal", UNKNOWN_EXCEPTION_CALLING_1808_API)
-        logger.error(s"[PEGAConnector][submitAppeal] -" +
-          s" An unknown exception occurred - returning 500 back to caller - message: ${e.getMessage}")
-        Left(UnexpectedFailure(INTERNAL_SERVER_ERROR, "An unknown exception occurred. Contact the Penalties team for more information."))
-      }
-    }
   }
 
   def headersForEIS(correlationId: String, bearerToken: String, environment: String): HeaderCarrier = {
     val headers = Seq(
-      "Environment"      -> environment,
+      "Environment"   -> environment,
       "CorrelationId" -> correlationId,
-      CONTENT_TYPE       -> MimeTypes.JSON,
-      ACCEPT             -> MimeTypes.JSON,
-      AUTHORIZATION -> s"Bearer $bearerToken"
+      CONTENT_TYPE    -> MimeTypes.JSON,
+      ACCEPT          -> MimeTypes.JSON,
+      AUTHORIZATION   -> s"Bearer $bearerToken"
     )
     HeaderCarrier(otherHeaders = headers)
   }

--- a/app/connectors/RegimePEGAConnector.scala
+++ b/app/connectors/RegimePEGAConnector.scala
@@ -17,12 +17,14 @@
 package connectors
 
 import config.AppConfig
+import config.featureSwitches.CallAPI1808HIP
 import connectors.parsers.AppealsParser.{AppealSubmissionResponse, AppealSubmissionResponseReads, UnexpectedFailure}
 import models.AgnosticEnrolmentKey
 import models.appeals.AppealSubmission
 import play.api.http.HeaderNames._
 import play.api.http.MimeTypes
 import play.api.http.Status.INTERNAL_SERVER_ERROR
+import play.api.libs.json.Writes
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, UpstreamErrorResponse}
 import utils.Logger.logger
 import utils.PagerDutyHelper
@@ -31,34 +33,44 @@ import utils.PagerDutyHelper.PagerDutyKeys._
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class RegimePEGAConnector @Inject()(httpClient: HttpClient,
-                                    appConfig: AppConfig)(implicit ec: ExecutionContext) {
+class RegimePEGAConnector @Inject() (httpClient: HttpClient, appConfig: AppConfig)(implicit ec: ExecutionContext) {
 
-  def submitAppeal(appealSubmission: AppealSubmission, enrolmentKey: AgnosticEnrolmentKey, isLPP: Boolean, penaltyNumber: String, correlationId: String): Future[AppealSubmissionResponse] = {
+  def submitAppeal(appealSubmission: AppealSubmission,
+                   enrolmentKey: AgnosticEnrolmentKey,
+                   isLPP: Boolean,
+                   penaltyNumber: String,
+                   correlationId: String): Future[AppealSubmissionResponse] = {
+
     implicit val hc: HeaderCarrier = headersForEIS(correlationId, appConfig.eiOutboundBearerToken, appConfig.eisEnvironment)
-    httpClient.POST[AppealSubmission, AppealSubmissionResponse](appConfig.getRegimeAgnosticAppealSubmissionUrl(enrolmentKey, isLPP, penaltyNumber), appealSubmission, hc.otherHeaders).recover {
-      case e: UpstreamErrorResponse => {
-        PagerDutyHelper.logStatusCode("submitAppeal", e.statusCode)(RECEIVED_4XX_FROM_1808_API, RECEIVED_5XX_FROM_1808_API)
-        logger.error(s"[RegimePEGAConnector][submitAppeal] -" +
-          s" Received ${e.statusCode} status from API 1808 call - returning status to caller")
-        Left(UnexpectedFailure(e.statusCode, e.message))
+    implicit val writesAppealSubmission: Writes[AppealSubmission] =
+      if (appConfig.isEnabled(CallAPI1808HIP)) AppealSubmission.apiWritesHIP else AppealSubmission.apiWrites
+    val submitAppealUrl = appConfig.getRegimeAgnosticAppealSubmissionUrl(enrolmentKey, isLPP, penaltyNumber)
+
+    httpClient
+      .POST[AppealSubmission, AppealSubmissionResponse](submitAppealUrl, appealSubmission, hc.otherHeaders)
+      .recover {
+        case e: UpstreamErrorResponse =>
+          PagerDutyHelper.logStatusCode("submitAppeal", e.statusCode)(RECEIVED_4XX_FROM_1808_API, RECEIVED_5XX_FROM_1808_API)
+          logger.error(
+            s"[RegimePEGAConnector][submitAppeal] -" +
+              s" Received ${e.statusCode} status from API 1808 call - returning status to caller")
+          Left(UnexpectedFailure(e.statusCode, e.message))
+        case e: Exception =>
+          PagerDutyHelper.log("submitAppeal", UNKNOWN_EXCEPTION_CALLING_1808_API)
+          logger.error(
+            s"[RegimePEGAConnector][submitAppeal] -" +
+              s" An unknown exception occurred - returning 500 back to caller - message: ${e.getMessage}")
+          Left(UnexpectedFailure(INTERNAL_SERVER_ERROR, "An unknown exception occurred. Contact the Penalties team for more information."))
       }
-      case e: Exception => {
-        PagerDutyHelper.log("submitAppeal", UNKNOWN_EXCEPTION_CALLING_1808_API)
-        logger.error(s"[RegimePEGAConnector][submitAppeal] -" +
-          s" An unknown exception occurred - returning 500 back to caller - message: ${e.getMessage}")
-        Left(UnexpectedFailure(INTERNAL_SERVER_ERROR, "An unknown exception occurred. Contact the Penalties team for more information."))
-      }
-    }
   }
 
   def headersForEIS(correlationId: String, bearerToken: String, environment: String): HeaderCarrier = {
     val headers = Seq(
-      "Environment"      -> environment,
+      "Environment"   -> environment,
       "CorrelationId" -> correlationId,
-      CONTENT_TYPE       -> MimeTypes.JSON,
-      ACCEPT             -> MimeTypes.JSON,
-      AUTHORIZATION -> s"Bearer $bearerToken"
+      CONTENT_TYPE    -> MimeTypes.JSON,
+      ACCEPT          -> MimeTypes.JSON,
+      AUTHORIZATION   -> s"Bearer $bearerToken"
     )
     HeaderCarrier(otherHeaders = headers)
   }

--- a/app/models/appeals/AppealSubmission.scala
+++ b/app/models/appeals/AppealSubmission.scala
@@ -488,7 +488,22 @@ object AppealSubmission {
     }
   }
 
-  implicit val apiWrites: Writes[AppealSubmission] = (appealSubmission: AppealSubmission) => {
+  val apiWrites: Writes[AppealSubmission] = (appealSubmission: AppealSubmission) => {
+    val dateOfAppealZoned: String = appealSubmission.dateOfAppeal.toInstant(ZoneOffset.UTC).toString
+    Json.obj(
+      "sourceSystem" -> appealSubmission.sourceSystem,
+      "taxRegime" -> appealSubmission.taxRegime,
+      "customerReferenceNo" -> appealSubmission.customerReferenceNo,
+      "dateOfAppeal" -> dateOfAppealZoned,
+      "isLPP" -> appealSubmission.isLPP,
+      "appealSubmittedBy" -> appealSubmission.appealSubmittedBy,
+      "appealInformation" -> parseAppealInformationToJson(appealSubmission.appealInformation)
+    ).deepMerge(
+      appealSubmission.agentDetails.fold(Json.obj())(agentDetails => Json.obj("agentDetails" -> agentDetails))
+    )
+  }
+
+  val apiWritesHIP: Writes[AppealSubmission] = (appealSubmission: AppealSubmission) => {
     val dateOfAppealZoned: String = appealSubmission.dateOfAppeal.toInstant(ZoneOffset.UTC).toString
     Json.obj(
       "sourceSystem" -> appealSubmission.sourceSystem,

--- a/test/models/appeals/AppealSubmissionSpec.scala
+++ b/test/models/appeals/AppealSubmissionSpec.scala
@@ -608,6 +608,8 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
       |   "lateAppeal": false
       |}
       |""".stripMargin)
+  
+  private val defaultAppealSubmissionWrites = AppealSubmission.apiWritesHIP
 
   "parseAppealInformationFromJson" should {
     "for bereavement" must {
@@ -1336,7 +1338,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
     }
   }
 
-  "apiWrites" should {
+  "apiWritesHIP" should {
     "for bereavement" must {
       "write the model to JSON" in {
         val modelToCovertToJson: AppealSubmission = AppealSubmission(
@@ -1381,10 +1383,11 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
           )
         )
 
-        val result = Json.toJson(modelToCovertToJson)(AppealSubmission.apiWrites)
+        val result = Json.toJson(modelToCovertToJson)(defaultAppealSubmissionWrites)
         result shouldBe jsonRepresentingModel
       }
     }
+
     "for crime" must {
       "write the model to JSON" in {
         val modelToConvertToJson: AppealSubmission = AppealSubmission(
@@ -1431,7 +1434,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
           )
         )
 
-        val result = Json.toJson(modelToConvertToJson)(AppealSubmission.apiWrites)
+        val result = Json.toJson(modelToConvertToJson)(defaultAppealSubmissionWrites)
         result shouldBe jsonRepresentingModel
       }
     }
@@ -1481,7 +1484,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
           )
         )
 
-        val result = Json.toJson(modelToConvertToJson)(AppealSubmission.apiWrites)
+        val result = Json.toJson(modelToConvertToJson)(defaultAppealSubmissionWrites)
         result shouldBe jsonRepresentingModel
       }
     }
@@ -1530,7 +1533,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
           )
         )
 
-        val result = Json.toJson(modelToConvertToJson)(AppealSubmission.apiWrites)
+        val result = Json.toJson(modelToConvertToJson)(defaultAppealSubmissionWrites)
         result shouldBe jsonRepresentingModel
       }
     }
@@ -1584,7 +1587,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
               "isClientResponsibleForLateSubmission" -> true
             )
           )
-          val result = Json.toJson(modelToConvertToJson)(AppealSubmission.apiWrites)
+          val result = Json.toJson(modelToConvertToJson)(defaultAppealSubmissionWrites)
           result shouldBe jsonRepresentingModel
         }
 
@@ -1634,7 +1637,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
               "isClientResponsibleForLateSubmission" -> true
             )
           )
-          val result = Json.toJson(modelToConvertToJson)(AppealSubmission.apiWrites)
+          val result = Json.toJson(modelToConvertToJson)(defaultAppealSubmissionWrites)
           result shouldBe jsonRepresentingModel
         }
 
@@ -1684,7 +1687,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
               "isClientResponsibleForLateSubmission" -> true
             )
           )
-          val result = Json.toJson(modelToConvertToJson)(AppealSubmission.apiWrites)
+          val result = Json.toJson(modelToConvertToJson)(defaultAppealSubmissionWrites)
           result shouldBe jsonRepresentingModel
         }
       }
@@ -1736,7 +1739,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
           )
         )
 
-        val result = Json.toJson(modelToConvertToJson)(AppealSubmission.apiWrites)
+        val result = Json.toJson(modelToConvertToJson)(defaultAppealSubmissionWrites)
         result shouldBe jsonRepresentingModel
       }
     }
@@ -1789,7 +1792,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
           )
         )
 
-        val result = Json.toJson(modelToConvertToJson)(AppealSubmission.apiWrites)
+        val result = Json.toJson(modelToConvertToJson)(defaultAppealSubmissionWrites)
         result shouldBe jsonRepresentingModel
       }
 
@@ -1839,7 +1842,7 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
           )
         )
 
-        val result = Json.toJson(modelToConvertToJson)(AppealSubmission.apiWrites)
+        val result = Json.toJson(modelToConvertToJson)(defaultAppealSubmissionWrites)
         result shouldBe jsonRepresentingModel
       }
 
@@ -1891,12 +1894,60 @@ class AppealSubmissionSpec extends AnyWordSpec with Matchers {
           )
         )
 
-        val result = Json.toJson(modelToConvertToJson)(AppealSubmission.apiWrites)
+        val result = Json.toJson(modelToConvertToJson)(defaultAppealSubmissionWrites)
         result shouldBe jsonRepresentingModel
       }
     }
   }
 
+  "apiWrites" should {
+    "write the model to JSON the same as apiWritesHIP, but excluding appealLevel from the model" in {
+        val modelToCovertToJson: AppealSubmission = AppealSubmission(
+          taxRegime = "VAT",
+          appealLevel = FirstStageAppeal,
+          customerReferenceNo = "123456789",
+          dateOfAppeal = LocalDateTime.parse("2020-01-01T00:00:00"),
+          isLPP = false,
+          appealSubmittedBy = "agent",
+          agentDetails = Some(AgentDetails(agentReferenceNo = "AGENT1", isExcuseRelatedToAgent = true)),
+          appealInformation = BereavementAppealInformation(
+            startDateOfEvent = "2021-04-23T00:00:00",
+            statement = None,
+            lateAppeal = true,
+            lateAppealReason = Some("Reason"),
+            isClientResponsibleForSubmission = Some(false),
+            isClientResponsibleForLateSubmission = Some(true),
+            honestyDeclaration = true,
+            reasonableExcuse = "bereavement"
+          )
+        )
+        val jsonRepresentingModel: JsValue = Json.obj(
+          "appealSubmittedBy" -> "agent",
+          "sourceSystem" -> "MDTP",
+          "taxRegime" -> "VAT",
+          "customerReferenceNo" -> "123456789",
+          "dateOfAppeal" -> "2020-01-01T00:00:00Z",
+          "isLPP" -> false,
+          "agentDetails" -> Json.obj(
+            "agentReferenceNo" -> "AGENT1",
+            "isExcuseRelatedToAgent" -> true
+          ),
+          "appealInformation" -> Json.obj(
+            "reasonableExcuse" -> "bereavement",
+            "honestyDeclaration" -> true,
+            "startDateOfEvent" -> "2021-04-23T00:00:00Z",
+            "lateAppeal" -> true,
+            "lateAppealReason" -> "Reason",
+            "isClientResponsibleForSubmission" -> false,
+            "isClientResponsibleForLateSubmission" -> true
+          )
+        )
+
+        val result = Json.toJson(modelToCovertToJson)(AppealSubmission.apiWrites)
+        result shouldBe jsonRepresentingModel
+      }
+  }
+  
   "BereavementAppealInformation" should {
     "bereavementAppealWrites" must {
       "write the appeal model to JSON" in {


### PR DESCRIPTION
As part of the HIP migration for 1808, we shall be sending the appealLevel to the API as part of the request body.
The appealLevel can be "01" or "02".
The VATC service shall only ever send "01", the ITSA service can send "01" or "02".
Until the HIP migration is live, appealLevel must be excluded from the submission.